### PR TITLE
examples: fix building with C allocator

### DIFF
--- a/examples/cart2pole/build.zig
+++ b/examples/cart2pole/build.zig
@@ -13,6 +13,7 @@ pub fn build(b: *std.Build) void {
         .root_source_file = .{ .path = "src/main.zig" },
         .target = target,
         .optimize = optimize,
+        .link_libc = true, // for C allocator
     });
 
     exe.addModule("zigNEAT", neat_module);

--- a/examples/cartpole/build.zig
+++ b/examples/cartpole/build.zig
@@ -13,6 +13,7 @@ pub fn build(b: *std.Build) void {
         .root_source_file = .{ .path = "src/main.zig" },
         .target = target,
         .optimize = optimize,
+        .link_libc = true, // for C allocator
     });
 
     exe.addModule("zigNEAT", neat_module);

--- a/examples/maze/build.zig
+++ b/examples/maze/build.zig
@@ -14,6 +14,7 @@ pub fn build(b: *std.Build) void {
         .root_source_file = .{ .path = "src/main.zig" },
         .target = target,
         .optimize = optimize,
+        .link_libc = true, // for C allocator
     });
 
     exe.addModule("zigNEAT", neat_module);

--- a/examples/retina/build.zig
+++ b/examples/retina/build.zig
@@ -14,6 +14,7 @@ pub fn build(b: *std.Build) void {
         .root_source_file = .{ .path = "src/main.zig" },
         .target = target,
         .optimize = optimize,
+        .link_libc = true, // for C allocator
     });
 
     exe.addModule("zigNEAT", neat_module);

--- a/examples/xor/build.zig
+++ b/examples/xor/build.zig
@@ -13,6 +13,7 @@ pub fn build(b: *std.Build) void {
         .root_source_file = .{ .path = "src/main.zig" },
         .target = target,
         .optimize = optimize,
+        .link_libc = true, // for C allocator
     });
 
     exe.addModule("zigNEAT", neat_module);


### PR DESCRIPTION
Usage of C allocator requires linking libc, but previously build system did not link it, and this caused error like below:

```zig
/usr/lib64/zig/9999/lib/std/heap.zig:37:13: error: C allocator is only available when linking against libc
            @compileError("C allocator is only available when linking against libc");
            ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/usr/lib64/zig/9999/lib/std/c/linux.zig:289:12: error: dependency on libc must be explicitly specified in the build command
pub extern "c" fn posix_memalign(memptr: *?*anyopaque, alignment: usize, size: usize) c_int;
```

After this commit examples build again.